### PR TITLE
Add horizontal scroll for week view

### DIFF
--- a/html/css/calendar.css
+++ b/html/css/calendar.css
@@ -1,3 +1,7 @@
+.weekly-calendar{
+    min-width:850px;
+}
+
 .calendar{
     background: #2CA8C2;
     color: #FFF;
@@ -113,4 +117,13 @@
 .calendar .cal-weekview-time-th>div {
     padding: 10px;
     min-height: 50px;
+}
+
+@media screen and (max-width:768px){
+    #weekly-calendar-container{
+        display: block;
+        overflow-x: scroll;
+        overflow-y: hidden;
+        white-space: nowrap;
+    }
 }

--- a/html/index.php
+++ b/html/index.php
@@ -156,6 +156,18 @@ $calendar->addEvents($events);
                 <div class="col-xs-12 col-sm-6 col-md-4">
                     
                     <?php echo $calendar->draw(date('Y-12-1'), 'purple'); ?>
+                    
+                    <hr />    
+
+                </div>
+
+            </div>
+
+            <div class="row">
+
+                <div class="col-xs-12">
+
+                    <?php echo $calendar->useWeekView()->draw(date('Y-12-1'), 'grey'); ?>
 
                 </div>
 

--- a/src/phpCalendar/Calendar.php
+++ b/src/phpCalendar/Calendar.php
@@ -414,7 +414,8 @@ class Calendar
      */
     public function stylesheet($print = true)
     {
-        $styles = '<style>.calendar{background:#2ca8c2;color:#fff;width:100%;font-family:Oxygen;table-layout:fixed}.calendar.purple{background:#913ccd}.calendar.pink{background:#f15f74}.calendar.orange{background:#f76d3c}.calendar.yellow{background:#f7d842}.calendar.green{background:#98cb4a}.calendar.grey{background:#839098}.calendar.blue{background:#5481e6}.calendar-title th{font-size:22px;font-weight:700;padding:20px;text-align:center;text-transform:uppercase;background:rgba(0,0,0,.05)}.calendar-header th{padding:10px;text-align:center;background:rgba(0,0,0,.1)}.calendar tbody tr td{text-align:center;vertical-align:top;width:14.28%}.calendar tbody tr td.pad{background:rgba(255,255,255,.1)}.calendar tbody tr td.day div:first-child{padding:4px;line-height:17px;height:25px}.calendar tbody tr td.day div:last-child{font-size:10px;padding:4px;min-height:25px}.calendar tbody tr td.today{background:rgba(0,0,0,.25)}.calendar tbody tr td.mask,.calendar tbody tr td.mask-end,.calendar tbody tr td.mask-start{background:#c23b22}.calendar .cal-weekview-time{padding:4px 2px 2px 4px;}.calendar .cal-weekview-time > div{background:rgba(0,0,0,0.03);padding:10px;min-height:50px;}.calendar .cal-weekview-event.mask-start,.calendar .cal-weekview-event.mask,.calendar .cal-weekview-event.mask-end{background:#C23B22;margin-bottom:3px;padding:5px;}.calendar .cal-weekview-time-th{background:rgba(0,0,0,.1);}.calendar .cal-weekview-time-th > div{padding:10px;min-height:50px;}</style>';
+        $styles = '<style>.weekly-calendar{min-width:850px;}.calendar{background:#2ca8c2;color:#fff;width:100%;font-family:Oxygen;table-layout:fixed}.calendar.purple{background:#913ccd}.calendar.pink{background:#f15f74}.calendar.orange{background:#f76d3c}.calendar.yellow{background:#f7d842}.calendar.green{background:#98cb4a}.calendar.grey{background:#839098}.calendar.blue{background:#5481e6}.calendar-title th{font-size:22px;font-weight:700;padding:20px;text-align:center;text-transform:uppercase;background:rgba(0,0,0,.05)}.calendar-header th{padding:10px;text-align:center;background:rgba(0,0,0,.1)}.calendar tbody tr td{text-align:center;vertical-align:top;width:14.28%}.calendar tbody tr td.pad{background:rgba(255,255,255,.1)}.calendar tbody tr td.day div:first-child{padding:4px;line-height:17px;height:25px}.calendar tbody tr td.day div:last-child{font-size:10px;padding:4px;min-height:25px}.calendar tbody tr td.today{background:rgba(0,0,0,.25)}.calendar tbody tr td.mask,.calendar tbody tr td.mask-end,.calendar tbody tr td.mask-start{background:#c23b22}.calendar .cal-weekview-time{padding:4px 2px 2px 4px;}.calendar .cal-weekview-time > div{background:rgba(0,0,0,0.03);padding:10px;min-height:50px;}.calendar .cal-weekview-event.mask-start,.calendar .cal-weekview-event.mask,.calendar .cal-weekview-event.mask-end{background:#C23B22;margin-bottom:3px;padding:5px;}.calendar .cal-weekview-time-th{background:rgba(0,0,0,.1);}.calendar .cal-weekview-time-th > div{padding:10px;min-height:50px;}</style>';
+        $styles .= '<style>@media screen and (max-width:768px){#weekly-calendar-container{display: block;overflow-x: scroll;overflow-y: hidden;white-space: nowrap;}}</style>';
 
         if ($print) {
             echo $styles;
@@ -825,6 +826,8 @@ class Calendar
     {
         $calendar = '';
 
+        $calendar .= '<div id="weekly-calendar-container">';
+
         $colspan = 7;
 
         $days = array_keys($this->days);
@@ -859,7 +862,7 @@ class Calendar
 
         $color = $color ?: '';
 
-        $calendar .= '<table class="calendar ' . $color . ' ' . implode(' ', $this->table_classes) . '">';
+        $calendar .= '<table class="weekly-calendar calendar ' . $color . ' ' . implode(' ', $this->table_classes) . '">';
 
         $calendar .= '<thead>';
 
@@ -885,7 +888,10 @@ class Calendar
         foreach ($this->getTimes() as $time) {
             $calendar .= '<tr>';
 
-            $calendar .= '<td class="cal-weekview-time-th"><div>' . $time . '</div></td>';
+            $start_time = $time;
+            $end_time = date('H:i', strtotime($time . ' + ' . ($this->time_interval) . ' minutes'));
+            
+            $calendar .= '<td class="cal-weekview-time-th"><div>' . $start_time . ' - ' . $end_time . '</div></td>';
             
             foreach ($dates as $date ){
 
@@ -940,6 +946,8 @@ class Calendar
         $calendar .= '</tbody>';
 
         $calendar .= '</table>';
+
+        $calendar .= '</div>';
 
         return $calendar;
     }


### PR DESCRIPTION
Hi maintainers!

I added the end time to 'cal-weekview-time-th' to provide clearance information for the time slots. However, this adjustment increases the table size, causing content overlap on smaller screens. To address this, I enabled horizontal scrolling for the weekly calendar.

Thanks,

Nazar