### PR TITLE
Added style class selectors to better handle situations where more than one calendar may be present

### DIFF
--- a/src/Views/Month.php
+++ b/src/Views/Month.php
@@ -40,11 +40,11 @@ class Month extends View
 
         $startDate = $this->options['startDate'];
 
-        $calendar .= sprintf('<table class="calendar  %s %s ">', $this->options['color'], $this->config->table_classes);
+        $calendar .= sprintf('<table class="calendar bh-calendar  %s %s ">', $this->options['color'], $this->config->table_classes);
 
         $calendar .= $this->getHeader($startDate);
 
-        $calendar .= '<tbody>';
+        $calendar .= '<tbody class="bh-calendar-body">';
 
         $calendar .= '<tr class="cal-week-'.$startDate->weekOfMonth.'">';
         $calendar .= $this->paddingBeforeTheMonthStartDate($startDate);
@@ -80,7 +80,7 @@ class Month extends View
     {
         $string = '<thead>';
 
-        $string .= '<tr class="calendar-title">';
+        $string .= '<tr class="calendar-title bh-calendar-title">';
 
         $colspan = 7 - count($this->config->getHiddenDays());
         $string .= '<th colspan="'.$colspan.'">';
@@ -90,7 +90,7 @@ class Month extends View
         $string .= '</th>';
 
         $string .= '</tr>';
-        $string .= '<tr class="calendar-header">';
+        $string .= '<tr class="calendar-header bh-calendar-header">';
 
         $carbonPeriod = Carbon::now()->locale($this->config->locale)->startOfWeek($this->config->starting_day)->toPeriod(7);
 

--- a/src/Views/Week.php
+++ b/src/Views/Week.php
@@ -51,8 +51,8 @@ class Week extends View
         $carbonPeriod = $startDate->locale($this->config->locale)->toPeriod(7);
 
         $calendar = [
-            '<div class="weekly-calendar-container">',
-            '<table class="weekly-calendar calendar ' . $this->options['color'] . ' ' . $this->config->table_classes . '">',
+            '<div class="weekly-calendar-container bh-weekly-calendar-container">',
+            '<table class="weekly-calendar bh-weekly-calendar calendar ' . $this->options['color'] . ' ' . $this->config->table_classes . '">',
             $this->makeHeader($carbonPeriod),
             '<tbody>',
             $this->renderBlocks($carbonPeriod),
@@ -105,7 +105,7 @@ class Week extends View
     {
         $headerString = '<thead>';
 
-        $headerString .= '<tr class="calendar-header">';
+        $headerString .= '<tr class="calendar-header bh-calendar-header">';
 
         $headerString .= '<th></th>';
 


### PR DESCRIPTION
This is to address a situation where using this library may collide with other calendar plugins or calendar stylings may be present.

This makes it easier to differentiate the BenHall14 Calendar bits from other bits.