### PR TITLE
Support arbitrary data attributes on calendar cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ Or, you can break it down with full customisability:
 	    'My Birthday',  # event name text
 	    true,           # should the date be masked - boolean default true
 	    ['myclass', 'abc'],   # (optional) additional classes in either string or array format to be included on the event days
-	    ['event-class', 'abc']   # (optional) additional classes in either string or array format to be included on the event summary box
+	    ['event-class', 'abc'],   # (optional) additional classes in either string or array format to be included on the event summary box
+        ['data-type' => 'holiday', 'data-holiday' => 'Independence Day'] # (optional) arbitrary data attributes to be included on the event day
 	);
 
     # or for multiple events
@@ -110,7 +111,8 @@ Or, you can break it down with full customisability:
 		'summary' => 'My Birthday',
 		'mask' => true,
 		'classes' => ['myclass', 'abc'],
-        'event_box_classes' => ['event-box-1']
+        'event_box_classes' => ['event-box-1'], 
+        'dataAttributes' => ['data-type' => 'holiday', 'data-holiday' => 'Independence Day']
 	);
 
 	$events[] = array(

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Or, you can break it down with full customisability:
 	    true,           # should the date be masked - boolean default true
 	    ['myclass', 'abc'],   # (optional) additional classes in either string or array format to be included on the event days
 	    ['event-class', 'abc'],   # (optional) additional classes in either string or array format to be included on the event summary box
-        ['data-type' => 'holiday', 'data-holiday' => 'Independence Day'] # (optional) arbitrary data attributes to be included on the event day
+	    ['data-type' => 'holiday', 'data-holiday' => 'Independence Day'] # (optional) arbitrary data attributes to be included on the event day
 	);
 
     # or for multiple events
@@ -111,8 +111,8 @@ Or, you can break it down with full customisability:
 		'summary' => 'My Birthday',
 		'mask' => true,
 		'classes' => ['myclass', 'abc'],
-        'event_box_classes' => ['event-box-1'], 
-        'dataAttributes' => ['data-type' => 'holiday', 'data-holiday' => 'Independence Day']
+		'event_box_classes' => ['event-box-1'], 
+		'dataAttributes' => ['data-type' => 'holiday', 'data-holiday' => 'Independence Day']
 	);
 
 	$events[] = array(

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -149,6 +149,7 @@ class Calendar
         bool $mask = false,
         string|array $classes = [],
         string|array $box_classes = [],
+        array $dataAttributes = []
     ): static {
         $this->events[] = new Event(
             Carbon::parse($start),
@@ -156,7 +157,8 @@ class Calendar
             $summary,
             $mask,
             $classes,
-            $box_classes
+            $box_classes, 
+            $dataAttributes
         );
 
         return $this;
@@ -180,7 +182,8 @@ class Calendar
             $mask = (bool) ($event['mask'] ?? false);
             $summary = $event['summary'] ?? '';
             $box_classes = $event['event_box_classes'] ?? '';
-            $this->addEvent($event['start'], $event['end'], $summary, $mask, $classes, $box_classes);
+            $dataAttributes = $event['dataAttributes'] ?? [];
+            $this->addEvent($event['start'], $event['end'], $summary, $mask, $classes, $box_classes, $dataAttributes);
         }
 
         return $this;

--- a/src/Event.php
+++ b/src/Event.php
@@ -11,6 +11,7 @@ class Event
     public string $box_classes;
 
     public string $classes;
+    public array $dataAttributes;
 
     /**
      * @param string|list<string> $classes
@@ -23,8 +24,10 @@ class Event
         public bool $mask = false,
         string|array $classes = '',
         string|array $box_classes = [],
+        array $dataAttributes = []
     ) {
         $this->classes = is_array($classes) ? implode(' ', $classes) : $classes;
         $this->box_classes = is_array($box_classes) ? implode(' ', $box_classes) : $box_classes;
+        $this->dataAttributes = $dataAttributes;
     }
 }

--- a/src/Views/Month.php
+++ b/src/Views/Month.php
@@ -142,6 +142,8 @@ class Month extends View
         $events = $this->findEvents((clone $runningDay)->startOfDay(), (clone $runningDay)->endOfDay());
 
         $classes = '';
+        $data_attrs = [];
+        $data_attrs_str = '';
         $event_summary = '';
         $today_class = $runningDay->isToday() ? ' today' : '';
         $string = '';
@@ -160,9 +162,16 @@ class Month extends View
             } elseif ($runningDay->isSameDay($event->end)) {
                 $classes .= $event->mask ? ' mask-end ' : '';
             }
+            // Apply data attributes.
+            if (isset($event->dataAttributes) && is_array($event->dataAttributes)) {
+                foreach ($event->dataAttributes as $attrname => $attrval) {
+                    $data_attrs[] = $attrname . '="' . $attrval . '"';
+                }
+                $data_attrs_str = implode(' ', $data_attrs);
+            }
         }
 
-        $dayRender = '<td class="day cal-day cal-day-'.strtolower($runningDay->englishDayOfWeek).' '.$classes.$today_class.'" title="'.htmlentities(strip_tags($event_summary)).'">';
+        $dayRender = '<td class="day cal-day cal-day-'.strtolower($runningDay->englishDayOfWeek).' '.$classes.$today_class.'" '.$data_attrs_str.' title="'.htmlentities(strip_tags($event_summary)).'">';
 
         $dayRender .= '<div class="cal-day-box">';
 


### PR DESCRIPTION
This package already has the ability to apply classnames to individual calendar cells. Its functionality can be further extended by supporting arbitrary data attributes on calendar cells. For example:

`<td class="day cal-day cal-day-tuesday holiday" data-type="holiday" data-holiday-name="Independence Day">`

This PR adds support for such data attributes. It also updates the README to describe the usage of that feature.